### PR TITLE
Fix npm build issue for Windows compatibility

### DIFF
--- a/ui-service/build.gradle
+++ b/ui-service/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
 	id 'java'
 	id 'base'
@@ -70,16 +72,20 @@ tasks.named('asciidoctor') {
 }
 
 tasks.register('npmBuild') {
-	doLast {
-		exec {
-			workingDir './src/main/frontend/hotel-booking-ui'
-			commandLine 'npm', 'install'
-		}
-		exec {
-			workingDir './src/main/frontend/hotel-booking-ui'
-			commandLine 'npm', 'run', 'build' // Command to run
-		}
-	}
+    doLast {
+        def npmCommand = Os.isFamily(Os.FAMILY_WINDOWS) ? 'npm.cmd' : 'npm'
+        def workingDirectory = './src/main/frontend/hotel-booking-ui'
+
+        exec {
+            workingDir workingDirectory
+            commandLine npmCommand, 'install'
+        }
+
+        exec {
+            workingDir workingDirectory
+            commandLine npmCommand, 'run', 'build'
+        }
+    }
 }
 
 tasks.named('build').configure {


### PR DESCRIPTION
This pull request addresses an issue with the `npmBuild` task failing on Windows systems due to the way the `npm` command is invoked.
The `npmBuild` task in `ui-service/build.gradle` was using `npm` as the command to install dependencies and build the frontend. On Windows, the correct command to invoke npm is `npm.cmd` instead of just `npm`.